### PR TITLE
Assign PYTHONPATH, not PYTHONUSERBASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This buildpack participates if `requirements.txt` exists at the root the app.
 The buildpack will do the following:
 * At build time:
   - Installs the application packages to a layer made available to the app.
-  - Sets the `PYTHONUSERBASE` to this layer.
+  - Prepends the layer site-packages onto `PYTHONPATH`.
 * At run time:
   - Does nothing
 
@@ -35,14 +35,14 @@ file that looks like the following:
   [requires.metadata]
 
     # Setting the build flag to true will ensure that the site-packages
-    # dependency is available on the $PYTHONUSERBASE for subsequent
+    # dependency is available on the $PYTHONPATH for subsequent
     # buildpacks during their build phase. If you are writing a buildpack that
     # needs site-packages during its build process, this flag should be
     # set to true.
     build = true
 
     # Setting the launch flag to true will ensure that the site-packages
-    # dependency is available on the $PYTHONUSERBASE for the running
+    # dependency is available on the $PYTHONPATH for the running
     # application. If you are writing an application that needs site-packages
     # at runtime, this flag should be set to true.
     launch = true

--- a/fakes/site_packages_process.go
+++ b/fakes/site_packages_process.go
@@ -1,0 +1,29 @@
+package fakes
+
+import "sync"
+
+type SitePackagesProcess struct {
+	ExecuteCall struct {
+		sync.Mutex
+		CallCount int
+		Receives  struct {
+			LayerPath string
+		}
+		Returns struct {
+			SitePackagesPath string
+			Err              error
+		}
+		Stub func(string) (string, error)
+	}
+}
+
+func (f *SitePackagesProcess) Execute(param1 string) (string, error) {
+	f.ExecuteCall.Lock()
+	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.LayerPath = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.SitePackagesPath, f.ExecuteCall.Returns.Err
+}

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitPipInstall(t *testing.T) {
 	suite("Detect", testDetect)
 	suite("Build", testBuild)
 	suite("InstallProcess", testInstallProcess)
+	suite("SiteProcess", testSiteProcess)
 	suite.Run(t)
 }

--- a/install_process.go
+++ b/install_process.go
@@ -71,6 +71,7 @@ func (p PipInstallProcess) Execute(workingDir, targetPath, cachePath string) err
 	}
 
 	p.logger.Subprocess("Running 'pip %s'", strings.Join(args, " "))
+
 	buffer := bytes.NewBuffer(nil)
 	err = p.executable.Execute(pexec.Execution{
 		Args:   args,
@@ -79,9 +80,8 @@ func (p PipInstallProcess) Execute(workingDir, targetPath, cachePath string) err
 		Stdout: buffer,
 		Stderr: buffer,
 	})
-
 	if err != nil {
-		return fmt.Errorf("pip install failed:\n%s\nerror: %w", buffer.String(), err)
+		return fmt.Errorf("pip install failed:\n%s\nerror: %w", buffer, err)
 	}
 
 	return nil

--- a/install_process_test.go
+++ b/install_process_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
@@ -49,18 +50,20 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 			err := pipInstallProcess.Execute(workingDir, packagesLayerPath, cacheLayerPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
-				"install",
-				"--requirement",
-				"requirements.txt",
-				"--exists-action=w",
-				fmt.Sprintf("--cache-dir=%s", cacheLayerPath),
-				"--compile",
-				"--user",
-				"--disable-pip-version-check",
+			Expect(executable.ExecuteCall.Receives.Execution).To(MatchFields(IgnoreExtras, Fields{
+				"Args": Equal([]string{
+					"install",
+					"--requirement",
+					"requirements.txt",
+					"--exists-action=w",
+					fmt.Sprintf("--cache-dir=%s", cacheLayerPath),
+					"--compile",
+					"--user",
+					"--disable-pip-version-check",
+				}),
+				"Dir": Equal(workingDir),
+				"Env": ContainElement(fmt.Sprintf("PYTHONUSERBASE=%s", packagesLayerPath)),
 			}))
-			Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal(workingDir))
-			Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("PYTHONUSERBASE=%s", packagesLayerPath)))
 		})
 
 		context("when vendor directory exists", func() {
@@ -72,20 +75,22 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				err := pipInstallProcess.Execute(workingDir, packagesLayerPath, cacheLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
-					"install",
-					"--requirement",
-					"requirements.txt",
-					"--ignore-installed",
-					"--exists-action=w",
-					"--no-index",
-					fmt.Sprintf("--find-links=%s", filepath.Join(workingDir, "vendor")),
-					"--compile",
-					"--user",
-					"--disable-pip-version-check",
+				Expect(executable.ExecuteCall.Receives.Execution).To(MatchFields(IgnoreExtras, Fields{
+					"Args": Equal([]string{
+						"install",
+						"--requirement",
+						"requirements.txt",
+						"--ignore-installed",
+						"--exists-action=w",
+						"--no-index",
+						fmt.Sprintf("--find-links=%s", filepath.Join(workingDir, "vendor")),
+						"--compile",
+						"--user",
+						"--disable-pip-version-check",
+					}),
+					"Dir": Equal(workingDir),
+					"Env": ContainElement(fmt.Sprintf("PYTHONUSERBASE=%s", packagesLayerPath)),
 				}))
-				Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal(workingDir))
-				Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("PYTHONUSERBASE=%s", packagesLayerPath)))
 			})
 		})
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -76,7 +76,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
-				MatchRegexp(fmt.Sprintf(`    PYTHONUSERBASE -> "/layers/%s/packages"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/packages/lib/python\d+\.\d+/site-packages:\$PYTHONPATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
 			))
 
 			container, err = docker.Container.Run.

--- a/run/main.go
+++ b/run/main.go
@@ -12,15 +12,14 @@ import (
 )
 
 func main() {
-	planner := draft.NewPlanner()
 	logger := scribe.NewEmitter(os.Stdout)
-	installProcess := pipinstall.NewPipInstallProcess(pexec.NewExecutable("pip"), logger)
 
 	packit.Run(
 		pipinstall.Detect(),
 		pipinstall.Build(
-			planner,
-			installProcess,
+			draft.NewPlanner(),
+			pipinstall.NewPipInstallProcess(pexec.NewExecutable("pip"), logger),
+			pipinstall.NewSiteProcess(pexec.NewExecutable("python")),
 			chronos.DefaultClock,
 			logger,
 		),

--- a/site_process.go
+++ b/site_process.go
@@ -1,0 +1,45 @@
+package pipinstall
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+// SiteProcess implements the Executable interface.
+type SiteProcess struct {
+	executable Executable
+}
+
+// NewSiteProcess creates an instance of the SiteProcess given an Executable that runs `python`
+func NewSiteProcess(executable Executable) SiteProcess {
+	return SiteProcess{
+		executable: executable,
+	}
+}
+
+// Execute runs a python command to locate the site packages within the pip targetLayerPath.
+func (p SiteProcess) Execute(layerPath string) (string, error) {
+	buffer := bytes.NewBuffer(nil)
+
+	err := p.executable.Execute(pexec.Execution{
+		Args:   []string{"-m", "site", "--user-site"},
+		Env:    append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", layerPath)),
+		Stdout: buffer,
+		Stderr: buffer,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to locate site packages:\n%s\nerror: %w", buffer.String(), err)
+	}
+
+	path := strings.TrimSpace(buffer.String())
+
+	if len(path) == 0 {
+		return "", fmt.Errorf("failed to locate site packages: output is empty")
+	}
+
+	return path, nil
+}

--- a/site_process_test.go
+++ b/site_process_test.go
@@ -1,0 +1,92 @@
+package pipinstall_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+	pipinstall "github.com/paketo-buildpacks/pip-install"
+	"github.com/paketo-buildpacks/pip-install/fakes"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testSiteProcess(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		layerPath  string
+		executable *fakes.Executable
+
+		process pipinstall.SiteProcess
+	)
+
+	it.Before(func() {
+		var err error
+		layerPath, err = ioutil.TempDir("", "layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		executable = &fakes.Executable{}
+		executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+			if execution.Stdout != nil {
+				fmt.Fprintln(execution.Stdout, filepath.Join(layerPath, "/pip/lib/python/site-packages"))
+			}
+			return nil
+		}
+
+		process = pipinstall.NewSiteProcess(executable)
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(layerPath)).To(Succeed())
+	})
+
+	context("Execute", func() {
+		context("there are site packages in the pip layer", func() {
+			it("returns the full path to the packages", func() {
+				sitePackagesPath, err := process.Execute(layerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.Receives.Execution.Env).To(Equal(append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", layerPath))))
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"-m", "site", "--user-site"}))
+
+				Expect(sitePackagesPath).To(Equal(filepath.Join(layerPath, "pip", "lib", "python", "site-packages")))
+			})
+		})
+
+		context("failure cases", func() {
+			context("site package lookup fails", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintln(execution.Stdout, "stdout output")
+						fmt.Fprintln(execution.Stderr, "stderr output")
+						return errors.New("locating site packages failed")
+					}
+				})
+
+				it("returns an error", func() {
+					_, err := process.Execute(layerPath)
+					Expect(err).To(MatchError(ContainSubstring("failed to locate site packages:")))
+					Expect(err).To(MatchError(ContainSubstring("stderr output")))
+					Expect(err).To(MatchError(ContainSubstring("error: locating site packages failed")))
+				})
+			})
+
+			context("when the site process returns nothing", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = nil
+				})
+
+				it("returns an error", func() {
+					_, err := process.Execute(layerPath)
+					Expect(err).To(MatchError("failed to locate site packages: output is empty"))
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Assigning `PYTHONUSERBASE` in this buildpack prevents subsequent buildpacks from adding modules to the application. Instead of assigning `PYTHONUSERBASE` the buildpack should prepend the modules installed onto the `PYTHONPATH`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Doing this will allow other buildpacks to use `PYTHONUSERBASE` without breaking the environment setup by this buildpack.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
