### PR TITLE
Remove `built_at` for more reproducible builds

### DIFF
--- a/build.go
+++ b/build.go
@@ -61,10 +61,6 @@ func Build(entryResolver EntryResolver, installProcess InstallProcess, siteProce
 		logger.Action("Completed in %s", duration.Round(time.Millisecond))
 		logger.Break()
 
-		packagesLayer.Metadata = map[string]interface{}{
-			"built_at": clock.Now().Format(time.RFC3339Nano),
-		}
-
 		packagesLayer.Launch, packagesLayer.Build = entryResolver.MergeLayerTypes(SitePackages, context.Plan.Entries)
 		packagesLayer.Cache = packagesLayer.Launch || packagesLayer.Build
 		cacheLayer.Cache = true

--- a/build_test.go
+++ b/build_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
@@ -31,10 +30,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		entryResolver       *fakes.EntryResolver
 		installProcess      *fakes.InstallProcess
 		sitePackagesProcess *fakes.SitePackagesProcess
-		clock               chronos.Clock
 
-		timeStamp time.Time
-		buffer    *bytes.Buffer
+		buffer *bytes.Buffer
 
 		build packit.BuildFunc
 	)
@@ -58,16 +55,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		buffer = bytes.NewBuffer(nil)
 
-		timeStamp = time.Now()
-		clock = chronos.NewClock(func() time.Time {
-			return timeStamp
-		})
-
 		build = pipinstall.Build(
 			entryResolver,
 			installProcess,
 			sitePackagesProcess,
-			clock,
+			chronos.DefaultClock,
 			scribe.NewEmitter(buffer),
 		)
 	})
@@ -111,9 +103,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Build:            false,
 					Launch:           false,
 					Cache:            false,
-					Metadata: map[string]interface{}{
-						"built_at": timeStamp.Format(time.RFC3339Nano),
-					},
+					Metadata:         nil,
 				},
 			},
 		}))
@@ -173,9 +163,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Build:            true,
 						Launch:           true,
 						Cache:            true,
-						Metadata: map[string]interface{}{
-							"built_at": timeStamp.Format(time.RFC3339Nano),
-						},
+						Metadata:         nil,
 					},
 				},
 			}))
@@ -222,9 +210,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Build:            false,
 						Launch:           true,
 						Cache:            true,
-						Metadata: map[string]interface{}{
-							"built_at": timeStamp.Format(time.RFC3339Nano),
-						},
+						Metadata:         nil,
 					},
 				},
 			}))
@@ -279,9 +265,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Build:            true,
 						Launch:           true,
 						Cache:            true,
-						Metadata: map[string]interface{}{
-							"built_at": timeStamp.Format(time.RFC3339Nano),
-						},
+						Metadata:         nil,
 					},
 					{
 						Name:             "cache",

--- a/fakes/entry_resolver.go
+++ b/fakes/entry_resolver.go
@@ -3,12 +3,12 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/packit/v2"
+	packit "github.com/paketo-buildpacks/packit/v2"
 )
 
 type EntryResolver struct {
 	MergeLayerTypesCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Name    string
@@ -23,8 +23,8 @@ type EntryResolver struct {
 }
 
 func (f *EntryResolver) MergeLayerTypes(param1 string, param2 []packit.BuildpackPlanEntry) (bool, bool) {
-	f.MergeLayerTypesCall.Lock()
-	defer f.MergeLayerTypesCall.Unlock()
+	f.MergeLayerTypesCall.mutex.Lock()
+	defer f.MergeLayerTypesCall.mutex.Unlock()
 	f.MergeLayerTypesCall.CallCount++
 	f.MergeLayerTypesCall.Receives.Name = param1
 	f.MergeLayerTypesCall.Receives.Entries = param2

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -4,7 +4,7 @@ import "sync"
 
 type InstallProcess struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir string
@@ -19,8 +19,8 @@ type InstallProcess struct {
 }
 
 func (f *InstallProcess) Execute(param1 string, param2 string, param3 string) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.WorkingDir = param1
 	f.ExecuteCall.Receives.TargetDir = param2

--- a/fakes/site_packages_process.go
+++ b/fakes/site_packages_process.go
@@ -4,7 +4,7 @@ import "sync"
 
 type SitePackagesProcess struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			LayerPath string
@@ -18,8 +18,8 @@ type SitePackagesProcess struct {
 }
 
 func (f *SitePackagesProcess) Execute(param1 string) (string, error) {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.LayerPath = param1
 	if f.ExecuteCall.Stub != nil {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -111,5 +111,6 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())
 	suite("Offline", testOffline, spec.Parallel())
+	suite("Reused", testReused, spec.Parallel())
 	suite.Run(t)
 }

--- a/integration/reused_test.go
+++ b/integration/reused_test.go
@@ -1,0 +1,86 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testReused(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			image1, image2 occam.Image
+			name           string
+			source         string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Image.Remove.Execute(image1.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image2.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("reuses layers", func() {
+			var err error
+			var logs1 fmt.Stringer
+			var logs2 fmt.Stringer
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
+
+			image1, logs1, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.PipInstall.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs1.String)
+
+			image2, logs2, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.PipInstall.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs2.String)
+
+			Expect(logs2).To(ContainLines(
+				"Reusing cache layer 'paketo-buildpacks/pip-install:packages'",
+			))
+
+			Expect(image2.Buildpacks[2].Layers["packages"].SHA).To(Equal(image1.Buildpacks[2].Layers["packages"].SHA))
+		})
+	})
+}


### PR DESCRIPTION
## Summary
Remove `built_at` for more reproducible builds. Resolves #113 .

## Use Cases
See #113 

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).