### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pip Install Cloud Native Buildpack
-The Paketo Pip Install Buildpack is a Cloud Native Buildpack that installs
+The Paketo Buildpack for Pip Install is a Cloud Native Buildpack that installs
 packages using pip and makes it available to the application.
 
 The buildpack is published for consumption at

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/pip-install"
-  name = "Paketo Pip Install Buildpack"
+  name = "Paketo Buildpack for Pip Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Pip Install Buildpack' to 'Paketo Buildpack for Pip Install'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
