### PR TITLE
Adding a note about PIP env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Will use `./vendor` if not provided.
 ```shell
 BP_PIP_DEST_PATH=my/custom/vendor-dir
 ```
+
+### `PIP_<UPPER_LONG_NAME>`
+
+It is worth noting that the `PIP_<UPPER_LONG_NAME>` configuration is respected by this buildpack and can be used to tweak the build time CLI properties for Pip as documented in [Pip's configuration](https://pip.pypa.io/en/stable/topics/configuration/#environment-variables)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Simply adding a note to make explicit how one would configure the pip install at build time.

## Use Cases
Say someone is in an environment with slow internet or large files to download. This would help them understand that `PIP_TIMEOUT` env var is available to them.

## Checklist
<!-- Please confirm the following -->
(I didn't do all of these but can if someone thinks this change belongs and/or someone can cherry pick)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
