### PR TITLE
Fail detection if BP_PIP_REQUIREMENT points to a non-existent file.

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -30,17 +30,21 @@ func Detect() packit.DetectFunc {
 			requirementsFile = envRequirement
 		}
 
-		anyRequirementsFileExists := false
+		missingRequirementFiles := []string{}
+		allRequirementsFilesExist := true
 		for _, filename := range strings.Split(requirementsFile, " ") {
 			found, err := fs.Exists(filepath.Join(context.WorkingDir, filename))
 			if err != nil {
 				return packit.DetectResult{}, err
 			}
-			anyRequirementsFileExists = anyRequirementsFileExists || found
+			if !found {
+				missingRequirementFiles = append(missingRequirementFiles, filename)
+			}
+			allRequirementsFilesExist = allRequirementsFilesExist && found
 		}
 
-		if !anyRequirementsFileExists {
-			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("requirements file not found at: '%s'", requirementsFile))
+		if !allRequirementsFilesExist {
+			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("requirements file not found at: '%s'", strings.Join(missingRequirementFiles, "', '")))
 		}
 
 		return packit.DetectResult{

--- a/detect.go
+++ b/detect.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/fs"
@@ -23,16 +24,23 @@ type BuildPlanMetadata struct {
 // and requires cpython and pip at build.
 func Detect() packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		_, requirementEnvExists := os.LookupEnv("BP_PIP_REQUIREMENT")
-		defaultRequirement := "requirements.txt"
-
-		defaultRequirementExists, err := fs.Exists(filepath.Join(context.WorkingDir, defaultRequirement))
-		if err != nil {
-			return packit.DetectResult{}, err
+		requirementsFile := "requirements.txt"
+		envRequirement, requirementEnvExists := os.LookupEnv("BP_PIP_REQUIREMENT")
+		if requirementEnvExists {
+			requirementsFile = envRequirement
 		}
 
-		if !requirementEnvExists && !defaultRequirementExists {
-			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("BP_PIP_REQUIREMENT not set and no '%s' found", defaultRequirement))
+		anyRequirementsFileExists := false
+		for _, filename := range strings.Split(requirementsFile, " ") {
+			found, err := fs.Exists(filepath.Join(context.WorkingDir, filename))
+			if err != nil {
+				return packit.DetectResult{}, err
+			}
+			anyRequirementsFileExists = anyRequirementsFileExists || found
+		}
+
+		if !anyRequirementsFileExists {
+			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("requirements file not found at: '%s'", requirementsFile))
 		}
 
 		return packit.DetectResult{


### PR DESCRIPTION
## Summary

In #257 we added support for `BP_PIP_REQUIREMENT` and in that PR the behavior was to pass detection simply based on the presence of the environment variable.

However, it is more desirable to fail-fast if that environment variable points to a non-existent file. The feedback loop of failing during detect is much faster than failing during build when trying to read the file.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
